### PR TITLE
Implement start command

### DIFF
--- a/private/cli/build.rkt
+++ b/private/cli/build.rkt
@@ -18,7 +18,7 @@
   (command-line
     #:program "build"
     #:args (dir)
-    (polyglot-project-directory (simplify-path dir))
+    (polyglot-project-directory (path->complete-path (simplify-path dir)))
     (report+summary (λ _
       (make-directory* (dist-rel))
       (empty-directory (dist-rel))

--- a/private/cli/develop.rkt
+++ b/private/cli/develop.rkt
@@ -49,7 +49,7 @@
     [("--delay") ms "The number of milliseconds to allow between changes "
                     "before trying to compile again. Default: 500."]
     #:args (dir)
-    (polyglot-project-directory (simplify-path dir))
+    (polyglot-project-directory (path->complete-path (simplify-path dir)))
     (make-directory* (dist-rel))
     (empty-directory (dist-rel))
     (send compiler add! (send compiler clarify "index.md"))

--- a/private/cli/entry.rkt
+++ b/private/cli/entry.rkt
@@ -14,6 +14,7 @@
   "build.rkt"
   "develop.rkt"
   "publish.rkt"
+  "start.rkt"
   "demo.rkt")
 
 (show-debug?       #f)
@@ -30,10 +31,12 @@
   ("develop" . "Build website in response to changes")
   ("publish" . "Publish website to S3 using your credentials file")
   ("demo"    . "Run demo page and place README.html in working directory")
+  ("start"   . "Create a new Polyglot project at a given directory")
   ("build"   . "Build the website once")))
 (define action-table `#hash(
   ("develop" . ,develop)
   ("publish" . ,publish)
+  ("start"   . ,start)
   ("demo"    . ,demo)
   ("build"   . ,build)))
 

--- a/private/cli/publish.rkt
+++ b/private/cli/publish.rkt
@@ -89,7 +89,7 @@
     [("-r" "--region")  reg ("Set AWS S3 region. Default: us-east-2")
                         (region reg)]
     #:args (dir s3-bucket-name)
-      (polyglot-project-directory dir)
+      (polyglot-project-directory (path->complete-path (simplify-path dir)))
       (bucket s3-bucket-name))
 
   (read-keys/aws-cli)

--- a/private/cli/start.rkt
+++ b/private/cli/start.rkt
@@ -1,0 +1,14 @@
+#lang racket/base
+
+(provide start)
+(require
+  racket/cmdline
+  racket/file
+  "../fs.rkt"
+  "../paths.rkt")
+
+(define (start)
+  (command-line
+    #:program "start"
+    #:args (dir)
+    (copy-directory/files (polyglot-rel "skel") dir)))

--- a/scribblings/polyglot.scrbl
+++ b/scribblings/polyglot.scrbl
@@ -31,23 +31,30 @@ directory contains a @italic{distribution} built from assets.
 @section{How to prepare a @racket[polyglot] project}
 
 @verbatim[#:indent 2]|{
-$ mkdir assets
-$ vim assets/index.md
+$ raco polyglot start my-website
+$ raco polyglot build my-website
+$ cd my-website
 $ raco polyglot build .
 }|
 
-The @racket["."] used in the build command is the designated @italic{project directory}.
-@racket[polyglot] expects to read all files in an @racket["assets"] directory therein, and to have
-write access to a @racket["dist"] directory. The @racket["dist"] directory will be
-created if it does not already exist. To start the build, @racket[polyglot] will try to
-load @racket["assets/index.md"].
+The @racket["my-website"] used in the start command creates a new @italic{project directory}
+with example content that uses @racket[polyglot]'s features. The code inside will contain
+helpful comments.
+
+@racket[polyglot] commands expect you to specify a path to a project directory to read, whereas @racket[start]
+will try to create a directory with the given name.
+
+When you run the @racket[build] command, @racket[polyglot] will read @racket["<project>/assets/index.md"]
+and write content to the @racket["<project>/dist"] directory, creating it if it does not already exist.
 
 As with the README, once you build the website you will see a dist directory appear.
-But instead of the directory appearing in your working directory, it will appear
+But instead of the directory appearing in your working directory, it will always appear
 in the project directory.
 
 In this example, @racket[polyglot] only parses Markdown, wraps the content in an HTML5
-document structure, and writes the resulting HTML to @racket["dist/index.html"].
+document structure, and writes the resulting HTML to @racket["dist/index.html"]. You
+will also see other files because @racket[polyglot] discovers dependencies of your pages
+and processes them too.
 
 @section{Writing Racket in Markdown}
 

--- a/skel/README.md
+++ b/skel/README.md
@@ -1,0 +1,7 @@
+This is an example that uses every `polyglot` feature.
+
+When in this directory...
+
+* `raco polyglot build .` builds the website once.
+* `raco polyglot develop .` watches changes in `assets` and rebuilds when you save a file.
+* `raco polyglot publish . BUCKET REGION` publishes the contents of `dist` to the given S3 bucket. [See documentation](https://docs.racket-lang.org/polyglot/index.html) for assumptions!

--- a/skel/assets/contact.md
+++ b/skel/assets/contact.md
@@ -1,0 +1,10 @@
+<script type="application/rackdown">
+#lang racket/base
+(require "project/vcomps.rkt") ; "project" is a symbolic link that points to where the project lives.
+(provide layout)
+(define layout (λ (kids) (page "Send a message" kids)))
+</script>
+<form action="/send" method="post">
+  <textarea style="width: 100%"></textarea>
+  <button style="display: block; padding: 1rem" type="submit">Send</button>
+</form>

--- a/skel/assets/index.md
+++ b/skel/assets/index.md
@@ -1,0 +1,34 @@
+<script type="application/rackdown">
+#lang racket
+
+;; This is an application element. It can control the page and generate content.
+
+;; 'project' is always a symbolic link to the project directory you give to polyglot.
+;; Use it to access shared resources.
+(require "project/vcomps.rkt")
+
+;; polyglot will look for a procedure that defines the layout for your page.
+;; Only application elements may provide a layout. If multiple elements provide a layout,
+;; polyglot will use only the last one received.
+(provide layout)
+
+(define layout (λ (kids) (page "Home" kids)))
+</script>
+
+This is your home page. `polyglot` sees `assets/index.md` as the entry point to your website.
+
+## Pages
+
+These are just links to other pages. You can reference then as links to Markdown files,
+and `polyglot` will process them in turn. This helps prevent broken links.
+
+* [A Website With Superpowers](racket-powered.md)
+* [Dummy contact form](contact.md)
+
+## Meta
+
+* [`polyglot` documentation][docs]
+* [Help pay for development!][pay]
+
+[pay]: https://www.paypal.com/paypalme2/sagegerard
+[docs]: https://docs.racket-lang.org/polyglot/index.html

--- a/skel/assets/racket-powered.md
+++ b/skel/assets/racket-powered.md
@@ -43,6 +43,7 @@ system knows to display the code for you to read, and then run it.
 (require racket/format racket/list)
 (provide sierpinsky-triangle)
 
+; Derived from https://goessner.net/articles/svg/fractals/index.html
 (define (sierpinsky-triangle iterations color id-prefix)
   (define (gid n) (format "~a~e" id-prefix n))
   (define (rf n) (format "#~a" (gid n)))

--- a/skel/assets/racket-powered.md
+++ b/skel/assets/racket-powered.md
@@ -1,0 +1,121 @@
+<script type="application/rackdown">
+#lang racket/base
+(require "project/vcomps.rkt")
+(provide layout)
+(define layout (λ (kids) (page "I Built This Website Using Racket. Here's What I Can Do Now." kids)))
+</script>
+
+_The original article can be found [here](https://sagegerard.com/racket-powered.html)._
+
+It looks like there's not much to see here. Isn't it great?
+Barring exceptional cases, every page on this website takes up fewer than
+20 kibibytes on disk and runs no JavaScript. Throttle your connection and
+hit refresh a few times. It loads in _milliseconds_. No one does that
+anymore.
+
+It's funny. I spent years learning the ins and outs of front-end
+web development, only to feel _happy_ making a tiny, 90s-looking
+page that loads in a blink of an eye with nothing to do but
+make a point. Is that ironic? I haven't decided yet.
+
+But I did not just write vanilla HTML and give up my shiny toys.
+I use [Racket][racket] to shape content using any language I want.
+What better tool for starting with a blank slate?
+
+## A Website With Superpowers
+
+Racket is a programming language programming language.
+Racket allows you to write your own languages in terms of itself, and
+it is a _joy_ to use. I released [`unlike-assets`][ua]&mdash;an open
+source build tool that functions as an alternative to Webpack for my
+purposes&mdash;to say thank you and to show off what it can do.
+
+I built a specific configuration for `unlike-assets` called [`polyglot`][rc]
+that lets me write web content with arbitrary DSLs.
+
+This snippet computes a Sierpinsky Triangle when building this page.
+A cool part about that is that I expressed the code only once. My
+system knows to display the code for you to read, and then run it.
+
+<script type="text/racket" id="tri">
+#lang racket/base
+
+(require racket/format racket/list)
+(provide sierpinsky-triangle)
+
+(define (sierpinsky-triangle iterations color id-prefix)
+  (define (gid n) (format "~a~e" id-prefix n))
+  (define (rf n) (format "#~a" (gid n)))
+  (define (iter n)
+    `(g ((id ,(gid n)))
+        ,@(map
+            (λ (matrix)
+               `(use ((xlink:href ,(rf (- n 1))) (transform ,matrix))))
+            '("matrix(0.5 0 0 0.5 0 0)"
+              "matrix(0.5 0 0 0.5 1 0)"
+              "matrix(0.5 0 0 0.5 0.5 0.866)"))))
+
+  `(svg ((xmlns "http://www.w3.org/2000/svg")
+         (xmlns:xlink "http://www.w3.org/1999/xlink")
+         (style "display: block; margin: 0 auto")
+         (width "200")
+         (height "175"))
+        (defs
+          (path ((id ,(gid 0)) (fill ,color) (d "M0 0,2 0,1 1.732 z"))))
+          ,@(map
+              iter
+              (range 1 (+ iterations 1)))
+          (use ((xlink:href ,(rf iterations)) (transform "scale(100)")))))
+</script>
+<script type="application/rackdown">
+#lang racket/base
+(require "project/vcomps.rkt")
+(write (rackdown-code-sample "fractal-example"
+    "#lang racket"
+    "(require \"tri.rkt\")"
+    "(write `(div ((style ,(string-join "
+    "                       '(\"margin: 0 auto\")"
+    "                       \";\")))"
+    "             ,(sierpinsky-triangle 4 \"#800\" \"tri\")))"))
+</script>
+
+Here I use [rash][rash]&mdash;a shell dialect by William Hatch&mdash;to compute the download size
+of Bootstrap. Honestly, I did it just because I can. I'd have to configure Webpack
+for countless hours to get this kind of flexibility.
+
+<script type="application/rackdown">
+#lang racket/base
+(require "project/vcomps.rkt")
+(write (rackdown-code-sample "alt-measure"
+  "#lang rash"
+  "(define size-box (box \"Unknown\"))"
+  ""
+  "curl -so /dev/null -w '\"%{size_download}\" \\"
+  "  https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css \\"
+  "  |>> set-box! size-box"
+  ""
+  "(write `(span ((style \"color: rebeccapurple\"))"
+  "        \"The total download size of Bootstrap v4.3.1 is \""
+  "        ,(unbox size-box) \" bytes\"))"))
+</script>
+
+This page starts as a Markdown file. Since Markdown supports use of HTML tags,
+I use `<script>` elements to express Racket modules that are available only
+within a page.
+
+* `text/racket` modules act as libraries.
+* `application/rackdown` elements write content and define page layout.
+
+I parse the Markdown, process the Racket code in a sensible order, and then
+scan for dependencies in `href` and `src` attributes (such as other pages) to
+automagically build the rest of the website until all dependencies are fulfilled.
+
+Things get fun when I can "drop down" from prose at any time to prepare
+a deeply integrated application that sits snug in any surrounding context.
+So if you are interested in using this kind of engine for your code, give
+[`polyglot`][rc] a try. If you want to start from a lower level, then use [`unlike-assets`][ua].
+
+[rash]: https://docs.racket-lang.org/rash/index.html
+[racket]: https://racket-lang.org/
+[ua]: https://github.com/zyrolasting/unlike-assets
+[rc]: https://github.com/zyrolasting/polyglot 

--- a/skel/assets/styles.css
+++ b/skel/assets/styles.css
@@ -1,0 +1,21 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 20px auto;
+  padding: 0 20px;
+  max-width: 50ch;
+  font-size: 20px;
+  line-height: 1.3;
+}
+
+.code-sample pre {
+  margin-bottom: 0;
+}
+
+.code-sample output {
+  display: block;
+  padding: 1rem;
+  border: 1px #222 solid;
+}

--- a/skel/vcomps.rkt
+++ b/skel/vcomps.rkt
@@ -22,7 +22,7 @@
   `(script ((type "application/rackdown") (id ,id))
            ,@lines))
 
-; ...such as actual code samples.
+; ...such as code samples combined with their actual output.
 (define (rackdown-code-sample name . lines)
   `(div ((class "code-sample"))
         (pre . ,(add-newlines lines))

--- a/skel/vcomps.rkt
+++ b/skel/vcomps.rkt
@@ -1,0 +1,29 @@
+#lang racket/base
+
+(require racket/list)
+(provide (all-defined-out))
+
+(define (page title kids)
+  `(html (head (title ,title)
+               (meta ((charset "utf-8")))
+               (meta ((name "viewport") (content "width=device-width, initial-scale=1")))
+               (link ((rel "stylesheet") (type "text/css") (href "styles.css")))) ; <-- polyglot counts styles.css as a dependency.
+         (body
+           (h1 ,title)
+           ,@kids)))
+
+(define (add-newlines lines)
+  (map (λ (l) (format "~a~n" l)) lines))
+
+; Note that this returns an application element. `polyglot` will do another pass if
+; it sees that application elements produce more application elements. This makes
+; it possible to generate more sophisticated content in terms of code...
+(define (meta-script id . lines)
+  `(script ((type "application/rackdown") (id ,id))
+           ,@lines))
+
+; ...such as actual code samples.
+(define (rackdown-code-sample name . lines)
+  `(div ((class "code-sample"))
+        (pre . ,(add-newlines lines))
+        (output ,(apply meta-script (cons name lines)))))


### PR DESCRIPTION
For those asking me for examples, here's a command that will create a starter website. The code inside has examples of `polyglot`'s features. 👍 

To test:

1. Pull down this branch
2. `raco pkg install --link`
3. Run the below:

```console
raco polyglot start my-website
cd my-website && ls   # Expected: A new directory with understandable content.
raco polyglot build . # Expected: a dist directory appears
ls dist               # Expected: Output content that you can serve.
```