### PR TITLE
Normalize exn handling

### DIFF
--- a/private/cli/build.rkt
+++ b/private/cli/build.rkt
@@ -23,4 +23,5 @@
       (make-directory* (dist-rel))
       (empty-directory (dist-rel))
       (send compiler add! (send compiler clarify "index.md"))
-      (send compiler compile!)))))
+      (with-handlers ([exn:fail? (λ (e) (<error "~a" (exn-message e)))])
+        (send compiler compile!))))))

--- a/private/cli/demo.rkt
+++ b/private/cli/demo.rkt
@@ -15,6 +15,6 @@
   (make-directory* (dist-rel))
 
   (with-report/void
-    (λ _ (with-handlers ([exn:fail? (λ (e) (<error "~a" e))])
+    (λ _ (with-handlers ([exn:fail? (λ (e) (<error "~a" (exn-message e)))])
          (send compiler add! asset)
          (send compiler compile!)))))

--- a/private/cli/develop.rkt
+++ b/private/cli/develop.rkt
@@ -34,7 +34,7 @@
 
 (define (build changed removed)
   (with-report/counts
-    (λ _ (with-handlers ([exn:fail? (λ (e) (<error "~a" e))])
+    (λ _ (with-handlers ([exn:fail? (λ (e) (<error "~a" (exn-message e)))])
                                  (send compiler compile!
                                        #:changed changed
                                        #:removed removed)))))

--- a/private/cli/publish.rkt
+++ b/private/cli/publish.rkt
@@ -95,6 +95,6 @@
   (read-keys/aws-cli)
   (s3-region (region))
 
-  (exit (with-handlers ([exn? (λ (e) (<error "~a" e) 1)])
+  (exit (with-handlers ([exn? (λ (e) (<error "~a" (exn-message e)) 1)])
           (with-report/void publish-website)
           0)))


### PR DESCRIPTION
The error handlers were not consistent, and one was missing on `build.rkt`, resulting in swallowed errors. Fast-tracking this one to make sure people can include more info in reports.