### PR TITLE
Remove broken content from example page

### DIFF
--- a/skel/assets/racket-powered.md
+++ b/skel/assets/racket-powered.md
@@ -8,32 +8,6 @@
 _This is an excerpt from the announcement page for the project.
 The original article can be found [here](https://sagegerard.com/racket-powered.html)._
 
-It looks like there's not much to see here. Isn't it great?
-Barring exceptional cases, every page on this website takes up fewer than
-20 kibibytes on disk and runs no JavaScript. Throttle your connection and
-hit refresh a few times. It loads in _milliseconds_. No one does that
-anymore.
-
-It's funny. I spent years learning the ins and outs of front-end
-web development, only to feel _happy_ making a tiny, 90s-looking
-page that loads in a blink of an eye with nothing to do but
-make a point. Is that ironic? I haven't decided yet.
-
-But I did not just write vanilla HTML and give up my shiny toys.
-I use [Racket][racket] to shape content using any language I want.
-What better tool for starting with a blank slate?
-
-## A Website With Superpowers
-
-Racket is a programming language programming language.
-Racket allows you to write your own languages in terms of itself, and
-it is a _joy_ to use. I released [`unlike-assets`][ua]&mdash;an open
-source build tool that functions as an alternative to Webpack for my
-purposes&mdash;to say thank you and to show off what it can do.
-
-I built a specific configuration for `unlike-assets` called [`polyglot`][rc]
-that lets me write web content with arbitrary DSLs.
-
 This snippet computes a Sierpinsky Triangle when building this page.
 A cool part about that is that I expressed the code only once. My
 system knows to display the code for you to read, and then run it.
@@ -88,16 +62,3 @@ within a page.
 * `text/racket` modules act as libraries.
 * `application/rackdown` elements write content and define page layout.
 
-I parse the Markdown, process the Racket code in a sensible order, and then
-scan for dependencies in `href` and `src` attributes (such as other pages) to
-automagically build the rest of the website until all dependencies are fulfilled.
-
-Things get fun when I can "drop down" from prose at any time to prepare
-a deeply integrated application that sits snug in any surrounding context.
-So if you are interested in using this kind of engine for your code, give
-[`polyglot`][rc] a try. If you want to start from a lower level, then use [`unlike-assets`][ua].
-
-[rash]: https://docs.racket-lang.org/rash/index.html
-[racket]: https://racket-lang.org/
-[ua]: https://github.com/zyrolasting/unlike-assets
-[rc]: https://github.com/zyrolasting/polyglot 

--- a/skel/assets/racket-powered.md
+++ b/skel/assets/racket-powered.md
@@ -5,7 +5,8 @@
 (define layout (λ (kids) (page "I Built This Website Using Racket. Here's What I Can Do Now." kids)))
 </script>
 
-_The original article can be found [here](https://sagegerard.com/racket-powered.html)._
+_This is an excerpt from the announcement page for the project.
+The original article can be found [here](https://sagegerard.com/racket-powered.html)._
 
 It looks like there's not much to see here. Isn't it great?
 Barring exceptional cases, every page on this website takes up fewer than
@@ -78,26 +79,6 @@ system knows to display the code for you to read, and then run it.
     "                       '(\"margin: 0 auto\")"
     "                       \";\")))"
     "             ,(sierpinsky-triangle 4 \"#800\" \"tri\")))"))
-</script>
-
-Here I use [rash][rash]&mdash;a shell dialect by William Hatch&mdash;to compute the download size
-of Bootstrap. Honestly, I did it just because I can. I'd have to configure Webpack
-for countless hours to get this kind of flexibility.
-
-<script type="application/rackdown">
-#lang racket/base
-(require "project/vcomps.rkt")
-(write (rackdown-code-sample "alt-measure"
-  "#lang rash"
-  "(define size-box (box \"Unknown\"))"
-  ""
-  "curl -so /dev/null -w '\"%{size_download}\" \\"
-  "  https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css \\"
-  "  |>> set-box! size-box"
-  ""
-  "(write `(span ((style \"color: rebeccapurple\"))"
-  "        \"The total download size of Bootstrap v4.3.1 is \""
-  "        ,(unbox size-box) \" bytes\"))"))
 </script>
 
 This page starts as a Markdown file. Since Markdown supports use of HTML tags,


### PR DESCRIPTION
I went too fast when I copied my announcement page source. It used `#lang rash`, which is not a declared dependency of `polyglot`. Users running `raco polyglot start` and then `build` would see the build fail because `rash` was not installed on their systems.

Here I trim down the page to just `#lang racket` use.