### PR TITLE
Let Racket dependencies advance assets

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define pkg-desc "An unlike compiler that generates static websites using a Markdown and any #lang")
 (define scribblings '(("scribblings/polyglot.scrbl" ())))
-(define version "0.0")
+(define version "0.1")
 (define pkg-authors '(sage))
 (define raco-commands
   '(("polyglot" polyglot/private/cli/entry "polyglot CLI" #f)))

--- a/main.rkt
+++ b/main.rkt
@@ -1,6 +1,13 @@
 #lang racket/base
 
-(provide polyglot%)
+(provide polyglot%
+         path-rel
+         polyglot-project-directory
+         polyglot-rel
+         project-rel
+         assets-rel
+         dist-rel
+         system-temp-rel)
 (require
   racket/path
   racket/class
@@ -8,6 +15,7 @@
   unlike-assets/policy
   "./private/fs.rkt"
   "./private/paths.rkt"
+  "./private/racket-as-asset.rkt"
   "./private/default-file-handling.rkt"
   "./private/rkdown/compiler.rkt")
 
@@ -16,6 +24,7 @@
       (define/override (delegate path)
         (case (path-get-extension path)
           [(#".md") markdown->dependent-xexpr]
+          [(#".rkt") delegate-to-asset-module]
           [else copy-hashed]))
 
       (define/override (clarify unclear)

--- a/main.rkt
+++ b/main.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
 (provide polyglot%
-         path-rel
+         path-el/c
          polyglot-project-directory
          polyglot-rel
          project-rel

--- a/private/paths.rkt
+++ b/private/paths.rkt
@@ -1,13 +1,9 @@
 #lang racket/base
 
-(require racket/runtime-path unlike-assets)
-(provide path-rel
-         polyglot-project-directory
-         polyglot-rel
-         project-rel
-         assets-rel
-         dist-rel
-         system-temp-rel)
+(require racket/contract
+         racket/runtime-path
+         unlike-assets)
+(provide (all-defined-out))
 
 (define polyglot-project-directory (make-parameter (current-directory)))
 
@@ -22,6 +18,12 @@
 (define (project-path-builder next)
   (λ rest (apply (path-rel (polyglot-project-directory) next)
                  rest)))
+
+; No enforcement here since that already comes with build-path
+; Provide for convenience in documentation and user-authored contracts.
+(define path-el/c (and/c (or/c path-for-some-system?
+                               path-string?)
+                         (not/c complete-path?)))
 
 (define project-rel     (project-path-builder "."))
 (define assets-rel      (project-path-builder "assets"))

--- a/private/racket-as-asset.rkt
+++ b/private/racket-as-asset.rkt
@@ -2,9 +2,11 @@
 
 (provide (all-defined-out))
 (require racket/contract
+         racket/rerequire
          unlike-assets
          unlike-assets/logging)
 
 (define/contract (delegate-to-asset-module clear compiler) advance/c
   (<info "Delegating to ~a's write-dist-file" clear)
+  (dynamic-rerequire clear)
   (dynamic-require clear 'write-dist-file))

--- a/private/racket-as-asset.rkt
+++ b/private/racket-as-asset.rkt
@@ -2,7 +2,9 @@
 
 (provide (all-defined-out))
 (require racket/contract
-         unlike-assets)
+         unlike-assets
+         unlike-assets/logging)
 
 (define/contract (delegate-to-asset-module clear compiler) advance/c
-  (dynamic-require clear 'advance))
+  (<info "Delegating to ~a's write-dist-file" clear)
+  (dynamic-require clear 'write-dist-file))

--- a/private/racket-as-asset.rkt
+++ b/private/racket-as-asset.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(provide (all-defined-out))
+(require racket/contract
+         unlike-assets)
+
+(define/contract (delegate-to-asset-module clear compiler) advance/c
+  (dynamic-require clear 'advance))

--- a/private/rkdown/compiler.rkt
+++ b/private/rkdown/compiler.rkt
@@ -31,9 +31,9 @@
          compiler))
 
   (define (ripple clear dep/clear history)
-    (if (equal? (path-get-extension clear) #".css")
-        next
-        (first history)))
+    (if (equal? (path-get-extension clear) #".md")
+        (first history)
+        next))
 
   (for ([unclear unclear-dependencies])
     (send compiler add!

--- a/scribblings/polyglot.scrbl
+++ b/scribblings/polyglot.scrbl
@@ -150,29 +150,55 @@ available.}]
 
 @section{Dependency discovery and processing}
 
-You may have noticed the links in the above example go to other Markdown files.
-This is a good time to bring up how @racket[polyglot] views the relationship
-between your web assets.
+You may have noticed in an earlier example that links can go to other Markdown files.
+
+@racketblock[
+(write `(a ((href "about.md"))))
+]
 
 @racket[polyglot] scans all @racket[href] and @racket[src] attribute values
-in a page once it has fully expanded. If those values look like they
-are meant to be paths (including @racket["file:"] URLs), they
-are considered dependencies of your page.
+in a page once that page no longer has any application or library elements.
+
+If any of those values look like they are meant to be paths
+(including @racket["file:"] URLs), they are considered dependencies of your page.
 
 Note that these values that are @bold{either absolute paths on
-your filesystem, or paths relative to your assets directory.}
+your filesystem, or paths relative to your assets directory} (See @racket[assets-rel]).
 So in the above example, @racket["about.md"] corresponds to
 a complete path like @racket[/home/sage/dir-from-command-line/assets/about.md].
+
+@subsection{Markdown Handling}
 
 @racket[polyglot] will iteratively discover and process any referenced Markdown
 files. All Markdown files will appear in the dist directory with the same
 name, except for the extension being changed to @racket[".html"].
 
-Any non-Markdown files you reference are copied to the dist directory,
-such that the file name is the first eight characters of the SHA1 hash of the
-file content. This is for cache busting in general.
+@subsection{Racket Module Handling}
 
-To customize this behavior, see @secref["extending"]
+Any referenced @racket[".rkt"] files are loaded using @racket[(dynamic-require path 'preprocess)].
+The module must @racket[(provide preprocess)] such that @racket[preprocess]
+is a procedure is a procedure that writes to some file in the dist directory
+and returns the complete path to that file.
+
+This allows you to turn this:
+
+@verbatim[#:indent 2]{
+<link href="compute-stylesheet.rkt" />
+}
+
+Into this:
+
+@verbatim[#:indent 2]{
+<link href="872a39fe.css" />
+}
+
+@subsection{Default File Handling}
+
+Any other files you reference are copied to the dist directory,
+such that the file name is the first eight characters of the SHA1 hash of the
+file content. This is strictly for cache busting.
+
+To customize any of the above behavior, see @secref["extending"]
 
 @section{Accessing shared content}
 

--- a/scribblings/polyglot.scrbl
+++ b/scribblings/polyglot.scrbl
@@ -180,10 +180,12 @@ Markdown file, except with an @racket[".html"] extension.
 
 @subsection{Racket Module Handling}
 
-Any referenced @racket[".rkt"] files are loaded using @racket[(dynamic-require path 'write-dist-file)].
-The module must @racket[(provide write-dist-file)] such that @racket[write-dist-file] is an
-@racket[advance/c] procedure that writes to some file in the dist directory
-and returns the complete path to the new file.
+Any referenced @racket[".rkt"] files load via @racket[(dynamic-require path 'write-dist-file)].
+The module must @racket[provide] @racket[write-dist-file] as an
+@racket[advance/c] procedure. That procedure must write to some file in the
+dist directory and return a complete path to the new file. @racket[polyglot]
+will replace the value of the @racket[src] or @racket[href] attribute with
+a path relative to the distribution for you.
 
 This allows you to turn this...
 

--- a/scribblings/polyglot.scrbl
+++ b/scribblings/polyglot.scrbl
@@ -268,7 +268,8 @@ $ raco polyglot develop .
 }|
 
 If a Markdown file changes, dependent markdown files will not rebuild.
-If a CSS file changes, dependent markdown files will only update outdated references to fulfilled dependencies.
+If any other file changes, dependent markdown files will rebuild
+starting from the dependency discovery stage.
 
 @section[#:tag "extending"]{Extending @racket[polyglot]}
 

--- a/scribblings/polyglot.scrbl
+++ b/scribblings/polyglot.scrbl
@@ -139,7 +139,11 @@ not be visited or instantiated until a Racket module
 in an application element tries to use it. To avoid confusion
 or unwanted output, avoid using the printer in the top-level
 of library element code.}
-@item{A Markdown+Racket file can have its own dependencies and therefore
+@item{The dependency discovery pass will not capture @racket[src] attributes for
+@racket["application/rackdown"] or @racket["text/racket"] @racket[script] elements
+because those elements would be replaced by the time @racket[polyglot] starts looking
+for dependencies.}
+@item{A Markdown+Racket file can have its own dependencies on Racket modules and therefore
 won't build on every system where @racket[polyglot] is installed. Be careful
 to use @racket[info.rkt] or a setup script to make your website's dependencies
 available.}]
@@ -217,6 +221,37 @@ attributes to complete paths if they are readable on your system. This is likely
 so you'd probably just want to override @method[unlike-compiler% delegate] to recognize new dependencies.
 
 You can even override Markdown processing entirely, but I wouldn't recommend it.
+}
+
+@section{Project paths}
+
+@racket[polyglot] uses several computed paths. You'll need them to process project files.
+
+@defthing[polyglot-project-directory (parameter/c complete-path?) #:value (current-directory)]{
+This is the primary directory where @racket[polyglot] will do its work. It may
+change according to user preferences and will impact the output of all below
+procedures:
+}
+
+@deftogether[(
+@defthing[path-el/c (and/c (or/c path-for-some-system? path-string?)
+                           (not/c complete-path?))]
+@defproc[(project-rel [path-element path-el/c] ...) path?]
+@defproc[(assets-rel [path-element path-el/c] ...) path?]
+@defproc[(dist-rel [path-element path-el/c] ...) path?]
+@defproc[(polyglot-rel [path-element path-el/c] ...) path?]
+@defproc[(system-temp-rel [path-element path-el/c] ...) path?]
+)]{
+These procedures behave like @racket[build-path], except each returns a path
+relative to a different directory:
+
+@itemlist[
+@item{@racket[project-rel] is relative to @racket[(polyglot-project-directory)].}
+@item{@racket[assets-rel] is relative to @racket[(project-rel "assets")]}
+@item{@racket[dist-rel] is relative to @racket[(project-rel "dist")]}
+@item{@racket[polyglot-rel] is relative to the @racket[polyglot] package's installation directory on your system.}
+@item{@racket[system-temp-rel] is relative to the temp directory where ephemeral modules will appear when processing Racket in your pages.}
+]
 }
 
 @section{Publishing to S3}

--- a/scribblings/polyglot.scrbl
+++ b/scribblings/polyglot.scrbl
@@ -181,6 +181,9 @@ Markdown file, except with an @racket[".html"] extension.
 @subsection{Racket Module Handling}
 
 Any referenced @racket[".rkt"] files load via @racket[(dynamic-require path 'write-dist-file)].
+If you are writing a website on a live build using the @racket[raco polyglot develop] command,
+changes to your Racket dependencies will be captured and reloaded using @racket[dynamic-rerequire].
+
 The module must @racket[provide] @racket[write-dist-file] as an
 @racket[advance/c] procedure. That procedure must write to some file in the
 dist directory and return a complete path to the new file. @racket[polyglot]


### PR DESCRIPTION
Let Racket modules generate assets when listed as page dependencies. 
This lets you write `<link href="compute-styles.rkt" />`, so that `polyglot` will turn it into `<link href="8ab954fe.css" />`.

Usage:
1. Name a `.rkt` file in a `href` or `src` attribute relative to your asset directory.
2. Write that `.rkt` module and have it `(provide write-dist-file)`, where `write-dist-file` is an [`advance/c` procedure](https://docs.racket-lang.org/unlike-assets/Fundamentals.html#%28def._%28%28lib._unlike-assets%2Fmain..rkt%29._advance%2Fc%29%29).
3. Write `write-dist-file` such that it returns a new absolute path to a replacement asset for the element. The basename of the path will become the new value of the `src` or `href` attribute.

Also, expose polyglot paths as part of the API.