### PR TITLE
Support preprocessing and element-level macros

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define pkg-desc "An unlike compiler that generates static websites using a Markdown and any #lang")
 (define scribblings '(("scribblings/polyglot.scrbl" (multi-page))))
-(define version "0.2")
+(define version "0.3")
 (define pkg-authors '(sage))
 (define raco-commands
   '(("polyglot" polyglot/private/cli/entry "polyglot CLI" #f)))

--- a/main.rkt
+++ b/main.rkt
@@ -13,9 +13,13 @@
          system-temp-rel)
 
 (require
-  racket/path
+  txexpr
   racket/class
+  racket/path
+  racket/rerequire
+  racket/string
   unlike-assets
+  unlike-assets/logging
   unlike-assets/policy
   "./private/fs.rkt"
   "./private/paths.rkt"
@@ -35,4 +39,34 @@
       (define/override (clarify unclear)
         (define path (build-complete-simple-path unclear (assets-rel)))
         (unless (file-readable? path) (error (format "Cannot read ~a" unclear)))
-        path)))
+        path)
+
+      (define/public (preprocess-txexprs tx-expressions)
+        (for/list ([tx (in-list tx-expressions)])
+          (define-values (new-content _)
+            (splitf-txexpr
+             tx
+             (λ (x)
+               (and (txexpr? x)
+                    (string? (attr-ref x 'data-macro #f))))
+             (λ (x)
+               (define modspec/list
+                 (regexp-split #px"\\s+"
+                               (string-trim (attr-ref x 'data-macro))))
+
+               (define module-path
+                 (assets-rel (format "~a.rkt"
+                                     (car modspec/list))))
+
+               (define provided
+                 (if (> (length modspec/list) 1)
+                     (string->symbol (cadr modspec/list))
+                     'replace-element))
+
+               (<debug "data-macro: load `~a` from `~a`"
+                       provided
+                       module-path)
+
+               (dynamic-rerequire module-path)
+               ((dynamic-require module-path provided) x))))
+          new-content))))

--- a/private/rkdown/compiler.rkt
+++ b/private/rkdown/compiler.rkt
@@ -23,7 +23,8 @@
 
 (define (markdown->dependent-xexpr clear compiler)
   (define txexpr/parsed (parse-markdown clear))
-  (define txexpr/expanded (run-txexpr! txexpr/parsed default-layout))
+  (define txexpr/preprocessed (send compiler preprocess-txexprs txexpr/parsed))
+  (define txexpr/expanded (run-txexpr! txexpr/preprocessed default-layout))
   (define unclear-dependencies (discover-dependencies txexpr/expanded))
 
   (define next

--- a/scribblings/default-workflow.scrbl
+++ b/scribblings/default-workflow.scrbl
@@ -177,6 +177,16 @@ describes how this works in tutorial form.
 If you override this, take care to call it from your subclass when you
 encounter Markdown or Racket files unless you know the consequences.
 }
+
+@defmethod[(preprocess-txexprs [tx-expressions (listof txexpr?)]) (listof txexpr?)]{
+In the default workflow, this method transforms @racket[tx-expressions] parsed
+from a source Markdown file into a new list of tagged X-expressions. This transformation
+occurs before processing any script elements with @racket[run-txexpr!].
+
+Use this to sanitize untrusted code, generate application elements based on content,
+or attach common metadata to documents.
+}
 }
 
+@include-section["macros.scrbl"]
 @include-section["publishing.scrbl"]

--- a/scribblings/macros.scrbl
+++ b/scribblings/macros.scrbl
@@ -1,0 +1,190 @@
+#lang scribble/manual
+
+@require[@for-label[racket/base racket/class txexpr polyglot]]
+
+@title[#:tag "polyglot-macros"]{Page Macros and Preprocessing}
+
+Racket macros replace Racket code inside of application elements and libraries.
+However, they do not operate on the page containing the elements themselves.
+
+Consider an application element that only sets the layout of the page.
+
+I omit the @racket[<script>] markup for brevity.
+
+@racketmod[racket/base
+(require "project/assets/layouts.rkt")
+(provide layout)
+(define layout (lambda (kids) (two-column "My Page Title" (nav-layout) kids)))
+]
+
+This is only 4 lines of code (6 if you count the @tt{<script>} tags),
+but it must duplicate for every page. This is especially tedious if all
+you want to do is change the title.
+
+A macro @italic{could} expand to this pattern of @racket[require], @racket[provide],
+and @racket[define], but that macro has to come from somewhere. If you @racket[require]
+that macro, the module path would still repeat across pages.
+
+@racketmod[racket/base
+(require "project/assets/macros.rkt")
+(layout (two-column "My Page Title" (nav-layout) kids))
+]
+
+If you bundle the macro as a binding in a new language,
+you still have the surrounding @racket[<script>] markup
+eating up bytes and your precious writing time.
+
+@verbatim[#:indent 2]{
+<script type="application/racket">
+#lang layout
+(two-column "My Page Title" (nav-layout) kids)
+</script>
+}
+
+To get around this, @racket[polyglot] can 
+match and replace elements before processing
+script elements.
+
+@section{Replace elements using @tt{data-macro}}
+
+Let's change the above example to use an element
+with a @tt{data-macro} attribute.
+
+@verbatim[#:indent 2]{
+<meta itemprop="build-time"
+      data-macro="set-layout"
+      data-title="My Page Title">
+}
+
+@margin-note{Why @tt{<meta itemprop>}?
+@itemlist[
+@item{HTML5 allows it in a @tt{<body>}}
+@item{It does not impact the appearance of a page when viewed by a human, but still adds meaning for a program.}
+@item{@tt{meta} is a void element, so you don't have to type a closing tag.}]}
+
+I use a @tt{<meta itemprop>} pattern here, but the element does not matter.
+@racket[polyglot] responds by trying to load the module at
+@racket[(assets-rel "set-layout.rkt")] and running a provided
+@racket[replace-element] procedure. We'll assume this implementation
+is handy.
+
+
+@racketmod[#:file "set-layout.rkt"
+racket/base
+
+(provide replace-element)
+
+(require txexpr)
+
+(define (replace-element target)
+  (define page-title (attr-ref target 'data-title))
+
+  (code:comment "polyglot will add new line characters for us.")
+  `(script ((type "application/racket"))
+    "#lang racket/base"
+    "(require \"project/assets/layouts.rkt\")"
+    "(provide layout)"
+    "(define (layout kids)"
+    ,(format "(two-column ~e (nav-layout) kids))" page-title)))
+]
+
+In this setup, @racket[target] is the entire @tt{<meta>} element
+as a @racket[txexpr]. @racket[replace-element] will simply return
+the layout-defining application element to take its place.
+
+If you are dreading writing one file per macro, don't worry.
+You can specify an expected provided identifier after the module
+name. This behaves the same way. @racket[replace-element] is just
+a default identifier to seek if none is specified.
+
+@verbatim[#:indent 2]|{
+<meta itemprop="build-time"
+      data-macro="set-layout replace-element"
+      data-title="My Page Title">
+}|
+
+@section{Pre-processing}
+
+If you don't want to use @tt{data-macro}, you'll need your own matching procedure.
+
+Subclass @racket[polyglot%] and override
+@method[polyglot% preprocess-txexprs].
+
+@racketblock[
+(require polyglot txexpr)
+
+(define polyglot+preprocessor%
+  (class* polyglot% ()
+    (super-new)
+    (define/override (preprocess-txexprs txexprs)
+      (for/list ([tx (in-list txexprs)])
+        (define-values (new-content _)
+          (splitf-txexpr
+           (λ (x) (and (txexpr? x)
+                       (equal? 'script)
+                       (equal? (attr-ref x 'type #f) "appliaction/racket")))
+           (λ (x) `(script ((type "application/racket"))
+                           "#lang limited"
+                           ,@(filter (λ (s) (not (string-contains? s "#lang")))
+                                     (get-elements x))))))
+        new-content))))
+]
+
+This makes @racket[polyglot] replace all application elements
+with new application elements under a prescribed limited
+language. This can be help with untrusted code.
+
+If you want to specialize @racket[polyglot]'s preprocessing
+and still leverage @tt{data-macro}, call @racket[(super preprocess-txexprs txexprs)]
+in your overriding method.
+
+
+@section{A Cautionary Tale About Invalid HTML}
+
+@racket[polyglot]'s Markdown parser happens to handle
+invalid elements, making code golf easy. But there's a
+gotcha.
+
+You could make the earlier @tt{data-macro} example use an undefined
+@tt{<m>} element, for example.
+
+@verbatim[#:indent 2]|{
+<m data-macro="set-layout replace-element"
+   data-title="My Page Title">
+}|
+
+If you have your own matcher, you can bring it all home.
+
+@verbatim[#:indent 2]|{
+<layout title="My Page Title">
+}|
+
+You can build this with @racket[polyglot], and you'll get output.
+
+Only it won't work as expected because you forgot to close the elements,
+XHTML style. If you add the missing @tt{/}s, it will work.
+
+@verbatim[#:indent 2]|{
+<m data-macro="set-layout replace-element"
+   data-title="My Page Title" />
+}|
+@verbatim[#:indent 2]|{
+<layout title="My Page Title" />
+}|
+
+XML rules? In @italic{my} HTML5?!
+
+The Markdown parser will treat HTML5 void elements as self-closing,
+but you must explicitly close anything you make up. If my opinion matters
+here, I'd strongly suggest @bold{only using valid HTML5}.
+
+For one thing, that is the document type that @racket[polyglot] delivers
+to end-users.
+
+Additionally, having valid HTML5 among Markdown helps keep your content
+decoupled from @racket[polyglot]'s default workflow.
+
+If you want to incorporate macro-like functionality among your prose
+(e.g. Wordpress shortcodes), remember that @racket[polyglot] operates
+on @racket[txexpr] values at its core.  You can always parse your own
+prose language instead of Markdown.


### PR DESCRIPTION
This release handles the headaches behind duplicated code for things like layouts in the default workflow. You can now use a `data-macro` attribute to specify a module and provided procedure to replace an element in a page.

If you have this in your Markdown file...

```
<meta itemprop="build-time" data-macro="my-module my-proc" title="My Page">
```

Then the element will be replaced by:

```
((dynamic-require (assets-rel "my-module.proc") 'my-proc)
  '(meta ((itemprop "build-time") (data-macro "my-module my-proc") (title "My Page")))
```