### PR TITLE
Expose `polyglot-temp-directory`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define pkg-desc "An unlike compiler that generates static websites using a Markdown and any #lang")
 (define scribblings '(("scribblings/polyglot.scrbl" (multi-page))))
-(define version "0.3")
+(define version "0.4")
 (define pkg-authors '(sage))
 (define raco-commands
   '(("polyglot" polyglot/private/cli/entry "polyglot CLI" #f)))

--- a/main.rkt
+++ b/main.rkt
@@ -6,6 +6,7 @@
          apply-manifest
          path-el/c
          polyglot-project-directory
+         polyglot-temp-directory
          polyglot-rel
          project-rel
          assets-rel

--- a/private/paths.rkt
+++ b/private/paths.rkt
@@ -6,6 +6,7 @@
 (provide (all-defined-out))
 
 (define polyglot-project-directory (make-parameter (current-directory)))
+(define polyglot-temp-directory (make-parameter (find-system-path 'temp-dir)))
 
 ; Use to bind path building functions
 (define (path-rel . head)
@@ -15,9 +16,14 @@
 
 (define-runtime-path polyglot-runtime-path "..")
 
-(define (project-path-builder next)
-  (λ rest (apply (path-rel (polyglot-project-directory) next)
+(define (path-builder base-rel next)
+  (λ rest (apply (path-rel (base-rel) next)
                  rest)))
+
+(define (project-path-builder next)
+  (path-builder polyglot-project-directory next))
+(define (temp-path-builder next)
+  (path-builder polyglot-temp-directory next))
 
 ; No enforcement here since that already comes with build-path
 ; Provide for convenience in documentation and user-authored contracts.
@@ -29,4 +35,4 @@
 (define assets-rel      (project-path-builder "assets"))
 (define dist-rel        (project-path-builder "dist"))
 (define polyglot-rel    (path-rel polyglot-runtime-path))
-(define system-temp-rel (path-rel (find-system-path 'temp-dir)))
+(define system-temp-rel (temp-path-builder "."))

--- a/scribblings/paths.scrbl
+++ b/scribblings/paths.scrbl
@@ -18,6 +18,16 @@ This is where @racket[polyglot] will do its most important work.
 As shown in @secref{setup}, you can specify this using the command-line interface.
 }
 
+@defthing[polyglot-temp-directory (parameter/c (and/c complete-path? directory-exists?)) #:value (find-system-path 'temp-rel)]{
+This is where @racket[polyglot] will store temporary Racket modules generated from your source code.
+
+This directory will experience frequent reads and writes during
+processing. To increase performance, set this to a directory using an
+in-memory filesystem like @tt{tempfs} (Assuming that
+@racket[(find-system-path 'temp-rel)] is not already on an in-memory
+filesystem).
+}
+
 @deftogether[(
 @defthing[path-el/c (and/c (or/c path-for-some-system? path-string?)
                            (not/c complete-path?))]
@@ -35,6 +45,6 @@ relative to a different directory:
 @item{@racket[assets-rel] is relative to @racket[(project-rel "assets")]. This is where @racket[polyglot] will look for files you use to develop your website.}
 @item{@racket[dist-rel] is relative to @racket[(project-rel "dist")]. This is where @racket[polyglot] will write output files that can be published for end-users to consume.}
 @item{@racket[polyglot-rel] is relative to the @racket[polyglot] package's installation directory on your system. This should not be used for production, but you can use this to access private modules and experiment with self-hosting builds.}
-@item{@racket[system-temp-rel] is relative to @racket[(find-system-path 'temp-dir)]. @racket[polyglot] uses this to prepare temporary files according to @secref{rackdown}}
+@item{@racket[system-temp-rel] is relative to @racket[(polyglot-temp-directory)]. @racket[polyglot] uses this to prepare temporary files according to @secref{rackdown}}
 ]
 }


### PR DESCRIPTION
Expose `polyglot-temp-directory` as a parameter controlling where `polyglot` will write temporary files. That way you can leverage an in-memory filesystem if it does not happen to live at `(find-system-path 'temp-dir)`