### PR TITLE
Fragment from macro

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define pkg-desc "An unlike compiler that generates static websites using a Markdown and any #lang")
 (define scribblings '(("scribblings/polyglot.scrbl" (multi-page))))
-(define version "0.4")
+(define version "0.5")
 (define pkg-authors '(sage))
 (define raco-commands
   '(("polyglot" polyglot/private/cli/entry "polyglot CLI" #f)))

--- a/scribblings/macros.scrbl
+++ b/scribblings/macros.scrbl
@@ -80,17 +80,22 @@ racket/base
   (define page-title (attr-ref target 'data-title))
 
   (code:comment "polyglot will add new line characters for us.")
-  `(script ((type "application/racket"))
+  (code:comment "NOTE: This is a LIST containing a script element!")
+  `((script ((type "application/racket"))
     "#lang racket/base"
     "(require \"project/assets/layouts.rkt\")"
     "(provide layout)"
     "(define (layout kids)"
-    ,(format "(two-column ~e (nav-layout) kids))" page-title)))
+    ,(format "(two-column ~e (nav-layout) kids))" page-title))))
 ]
 
 In this setup, @racket[target] is the entire @tt{<meta>} element
 as a @racket[txexpr]. @racket[replace-element] will simply return
 the layout-defining application element to take its place.
+
+@italic{Take careful note that @racket[replace-element] is returning a list
+containing only a @tt{script} element.} Like application elements, procedures
+acting as macros can replace one element with many.
 
 If you are dreading writing one file per macro, don't worry.
 You can specify an expected provided identifier after the module

--- a/scribblings/macros.scrbl
+++ b/scribblings/macros.scrbl
@@ -94,8 +94,8 @@ as a @racket[txexpr]. @racket[replace-element] will simply return
 the layout-defining application element to take its place.
 
 @italic{Take careful note that @racket[replace-element] is returning a list
-containing only a @tt{script} element.} Like application elements, procedures
-acting as macros can replace one element with many.
+containing only a @tt{script} element.} Like application elements,
+these procedures can replace one element with many.
 
 If you are dreading writing one file per macro, don't worry.
 You can specify an expected provided identifier after the module


### PR DESCRIPTION
I missed a detail in the macros api: It should support replacing one element with many just like application elements did. This is a breaking change, but since the API dropped as of a few hours ago I'll take an aggressive stance and put this out there.  