### PR TITLE
Use polyglot% subclass via CLI

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define pkg-desc "An unlike compiler that generates static websites using a Markdown and any #lang")
 (define scribblings '(("scribblings/polyglot.scrbl" (multi-page))))
-(define version "0.5")
+(define version "0.6")
 (define pkg-authors '(sage))
 (define raco-commands
   '(("polyglot" polyglot/private/cli/entry "polyglot CLI" #f)))

--- a/private/cli/build.rkt
+++ b/private/cli/build.rkt
@@ -14,7 +14,7 @@
 
 
 (define (build)
-  (define compiler (new polyglot%))
+  (define compiler (new (polyglot-class)))
   (command-line
     #:program "build"
     #:args (dir)

--- a/private/cli/develop.rkt
+++ b/private/cli/develop.rkt
@@ -16,7 +16,7 @@
   "shared.rkt")
 
 (define timeout (make-parameter 500))
-(define compiler (new polyglot%))
+(define compiler (new (polyglot-class)))
 
 (define (changed? activity)
   (equal? (second activity) 'change))

--- a/private/cli/entry.rkt
+++ b/private/cli/entry.rkt
@@ -15,7 +15,8 @@
   "develop.rkt"
   "publish.rkt"
   "start.rkt"
-  "demo.rkt")
+  "demo.rkt"
+  "shared.rkt")
 
 (show-debug?       #f)
 (show-colors?      #t)
@@ -58,6 +59,10 @@
     #:once-each
     [("-v" "--verbose")       "Include debug-level logging in output"
                               (show-debug? #t)]
+    [("-b" "--by-module") module-path
+                          "Use alternative polyglot% (sub)class provided as `polyglot+%`"
+                          "from module-path"
+                          (polyglot-class (dynamic-require module-path 'polyglot+%))]
     #:args (action . _)
     (parameterize ([current-command-line-arguments (get-subcommand-args action)])
       ((hash-ref action-table action (λ _ show-subcommands))))))

--- a/private/cli/shared.rkt
+++ b/private/cli/shared.rkt
@@ -3,7 +3,10 @@
 (provide (all-defined-out))
 
 (require racket/dict
-         unlike-assets/logging)
+         unlike-assets/logging
+         "../../main.rkt")
+
+(define polyglot-class (make-parameter polyglot%))
 
 (define (report+summary proc)
   (define counts (with-report/counts proc))

--- a/scribblings/default-workflow.scrbl
+++ b/scribblings/default-workflow.scrbl
@@ -188,5 +188,28 @@ or attach common metadata to documents.
 }
 }
 
+@section{Using Your @racket[polyglot%] Extensions}
+
+When you subclass @racket[polyglot%], it won't apply to the
+default workflow unless you tell the CLI to use it.
+
+First, write your subclass in a module and expose it using
+@racket[(provide polyglot+%)].
+
+@racketmod[#:file "my-polyglot.rkt"
+racket/base
+(require racket/class polyglot)
+(provide polyglot+%)
+(define polyglot+% (class* polyglot% () (super-new) #;...))
+]
+
+Then, using the CLI, specify your module using
+after the @tt{polyglot} command, but before the
+subcommand.
+
+@verbatim[#:indent 2]|{
+$ raco polyglot -b my-polyglot.rkt build my-site
+}|
+
 @include-section["macros.scrbl"]
 @include-section["publishing.scrbl"]


### PR DESCRIPTION
Subclassing polyglot won't be convenient unless the CLI is involved. Add the `-b`/`--by-module` option to support specifying a custom `polyglot%` compiler.