### PR TITLE
Show error context

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define pkg-desc "An unlike compiler that generates static websites using a Markdown and any #lang")
 (define scribblings '(("scribblings/polyglot.scrbl" (multi-page))))
-(define version "0.6")
+(define version "0.7")
 (define pkg-authors '(sage))
 (define raco-commands
   '(("polyglot" polyglot/private/cli/entry "polyglot CLI" #f)))

--- a/private/cli/build.rkt
+++ b/private/cli/build.rkt
@@ -23,5 +23,5 @@
       (make-directory* (dist-rel))
       (empty-directory (dist-rel))
       (send compiler add! (send compiler clarify "index.md"))
-      (with-handlers ([exn:fail? (λ (e) (<error "~a" (exn-message e)))])
+      (with-handlers ([exn:fail? log-exn])
         (send compiler compile!))))))

--- a/private/cli/demo.rkt
+++ b/private/cli/demo.rkt
@@ -7,7 +7,8 @@
   unlike-assets/logging
   "../../main.rkt"
   "../fs.rkt"
-  "../paths.rkt")
+  "../paths.rkt"
+  "shared.rkt")
 
 (define (demo)
   (define compiler (new polyglot%))
@@ -15,6 +16,6 @@
   (make-directory* (dist-rel))
 
   (with-report/void
-    (λ _ (with-handlers ([exn:fail? (λ (e) (<error "~a" (exn-message e)))])
+    (λ _ (with-handlers ([exn:fail? log-exn])
          (send compiler add! asset)
          (send compiler compile!)))))

--- a/private/cli/develop.rkt
+++ b/private/cli/develop.rkt
@@ -45,7 +45,7 @@
 
     (define (build changed removed)
       (with-report/counts
-        (λ _ (with-handlers ([exn:fail? (λ (e) (<error "~a" (exn-message e)))])
+        (λ _ (with-handlers ([exn:fail? log-exn])
                (send compiler compile!
                      #:changed changed
                      #:removed removed)))))

--- a/private/cli/publish.rkt
+++ b/private/cli/publish.rkt
@@ -12,7 +12,8 @@
   aws/keys
   "../../main.rkt"
   "../fs.rkt"
-  "../paths.rkt")
+  "../paths.rkt"
+  "shared.rkt")
 
 (define bucket (make-parameter "default-bucket"))
 (define dry-run? (make-parameter #f))
@@ -95,6 +96,6 @@
   (read-keys/aws-cli)
   (s3-region (region))
 
-  (exit (with-handlers ([exn? (λ (e) (<error "~a" (exn-message e)) 1)])
+  (exit (with-handlers ([exn? (λ (e) (log-exn e) 1)])
           (with-report/void publish-website)
           0)))

--- a/private/cli/shared.rkt
+++ b/private/cli/shared.rkt
@@ -9,7 +9,11 @@
 (define polyglot-class (make-parameter polyglot%))
 
 (define (log-exn e)
-  (<error "~a" ((error-display-handler) (exn-message e) e)))
+  (define string-port (open-output-string))
+  (parameterize ([current-error-port string-port])
+    ((error-display-handler) (exn-message e) e))
+
+  (<error (get-output-string string-port)))
 
 (define (report+summary proc)
   (define counts (with-report/counts proc))

--- a/private/cli/shared.rkt
+++ b/private/cli/shared.rkt
@@ -5,6 +5,9 @@
 (require racket/dict
          unlike-assets/logging)
 
+(define (log-exn e)
+  (<error "~a" ((error-display-handler) (exn-message e) e)))
+
 (define (report+summary proc)
   (define counts (with-report/counts proc))
   (define nwarnings (dict-ref counts 'warning 0))


### PR DESCRIPTION
The error-level log events on compilation failure did not show context. That got old.