### PR TITLE
Distinguish 'aggressive' and 'passive' replacement behavior

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define pkg-desc "An unlike compiler that generates static websites using a Markdown and any #lang")
 (define scribblings '(("scribblings/polyglot.scrbl" (multi-page))))
-(define version "0.9")
+(define version "1.0")
 (define pkg-authors '(sage))
 (define raco-commands
   '(("polyglot" polyglot/private/cli/entry "polyglot CLI" #f)))

--- a/txexpr.rkt
+++ b/txexpr.rkt
@@ -53,6 +53,16 @@
                             symbol?
                             (-> txexpr? (listof txexpr?))
                             txexpr?)]
+                       [tx-replace/aggressive
+                        (-> txexpr?
+                            txe-predicate/c
+                            (-> txexpr-element? (listof txexpr?))
+                            txexpr?)]
+                       [tx-replace-tagged/aggressive
+                        (-> txexpr?
+                            symbol?
+                            (-> txexpr? (listof txexpr?))
+                            txexpr?)]
                        [interlace-txexprs
                         (->* ((or/c txexpr?
                                     (non-empty-listof txexpr?))
@@ -203,6 +213,11 @@
 
 (define (tx-replace tx replace? replace)
   (let-values ([(next _)
+                (substitute-many-in-txexpr tx replace? replace)])
+    next))
+
+(define (tx-replace/aggressive tx replace? replace)
+  (let-values ([(next _)
                 (substitute-many-in-txexpr/loop tx
                                                 replace?
                                                 replace)])
@@ -212,6 +227,11 @@
   (tx-replace tx
               (λ (x) (tag-equal? t x))
               replace))
+
+(define (tx-replace-tagged/aggressive tx t replace)
+  (tx-replace/aggressive tx
+                         (λ (x) (tag-equal? t x))
+                         replace))
 
 (define (tx-search-tagged tx t)
   (or (findf*-txexpr tx (λ (x) (tag-equal? t x)))


### PR DESCRIPTION
This PR marks the first breaking change, although it pertains to the new txexpr API and won't impact most users.

Before, nothing warned the user that `tx-replace` and other procedures would aggressively try to replace all elements matching a predicate, including those in the replacement itself. It was therefore easy to set up infinite loops when you did something conventional like replace an element with the same element plus one child.

The breaking change was to make `tx-replace` "passive", such that it allowed matching elements to appear in replacements. I documented the difference between "aggressive" and "passive". I do not expect that users have already become dependent on the aggressive behavior, and actually expect that it would be unwanted. That's why I view the change in behavior as a bugfix for 95% of cases. But if you are of the 5% that want the aggressive behavior, please change the relevant calls from `tx-replace` to `tx-replace/aggressive` and accept my apologies for having you do so (I'd honestly be surprised if you got used to it so quickly, though).