### PR TITLE
Support CSS dependency discovery

### DIFF
--- a/base.rkt
+++ b/base.rkt
@@ -21,7 +21,8 @@
          unlike-assets/policy
          "./txexpr.rkt"
          "./paths.rkt"
-         "./private/fs.rkt")
+         "./private/fs.rkt"
+         "./private/css.rkt")
 
 (define (make-minimal-html-page body)
   `(html (head (title "Untitled")) (body . ,body)))
@@ -111,6 +112,7 @@
   (class* unlike-compiler% () (super-new)
     (define/override (delegate path)
       (case (path-get-extension path)
+        [(#".css") process-css]
         [(#".rkt") delegate-to-asset-module]
         [else copy-hashed]))
 

--- a/info.rkt
+++ b/info.rkt
@@ -4,7 +4,7 @@
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define pkg-desc "An unlike compiler that generates static websites using a Markdown and any #lang")
 (define scribblings '(("scribblings/polyglot.scrbl" (multi-page))))
-(define version "1.0")
+(define version "1.1")
 (define pkg-authors '(sage))
 (define raco-commands
   '(("polyglot" polyglot/private/cli/entry "polyglot CLI" #f)))

--- a/private/css.rkt
+++ b/private/css.rkt
@@ -1,0 +1,61 @@
+#lang racket/base
+
+;; Responsible for default handling of CSS, in which
+;; url() expressions are dependency references.
+
+(provide process-css)
+(require racket/class
+         racket/file
+         racket/list
+         racket/path
+         racket/port
+         racket/string
+         file/sha1
+         unlike-assets/policy
+         unlike-assets/logging
+         "../paths.rkt")
+
+(define (process-css clear compiler)
+  (define rx-matches (call-with-input-file #:mode 'text clear discover-dependencies))
+  (define advance (chain write-css clear compiler rx-matches))
+  (define unclear-dependencies (map cadr rx-matches))
+  (for ([unclear unclear-dependencies])
+    (send compiler add! (send compiler clarify unclear) clear (λ _ advance)))
+  advance)
+
+(define (write-css clear compiler rx-matches)
+  (define css-text
+    (for/fold ([css (file->string clear)])
+              ([rx-match rx-matches])
+      (string-replace css
+                      (car rx-match)
+                      (format "url('~a')"
+                              (send compiler
+                                    lookup
+                                    (send compiler
+                                          clarify
+                                          (cadr rx-match)))))))
+  (define dst
+    (call-with-input-string
+      css-text
+      (λ (port)
+        (dist-rel
+         (path-replace-extension
+          (substring (sha1 port) 0 8)
+          #".css")))))
+  (with-output-to-file dst #:exists 'replace
+    (λ () (displayln css-text)))
+  (<info "Wrote ~a" dst)
+  dst)
+
+(define (discover-dependencies in)
+  (filter-map
+   (λ (match-list)
+     (define encoded (if (bytes? (car match-list))
+                         (map bytes->string/utf-8 match-list)
+                         match-list))
+     (and (local-asset-url? (cadr encoded))
+          encoded))
+   (regexp-match* #px"url\\([\"']?([^\\)\"']+)[\"']?\\)"
+                  in
+                  #:match-select values)))

--- a/scribblings/workflows.scrbl
+++ b/scribblings/workflows.scrbl
@@ -272,8 +272,8 @@ You can use this technique to take full responsibility for how
 an asset is used in a distribution within a built-in workflow.
 
 @subsection{CSS Handling (@racket[".css"])}
-In CSS, the values in @litchar{url()} expressions are evaluated just
-like @tt{href} and @tt{src} attribute values in
+In CSS, the values in @litchar{url()} expressions are treated just
+like the @tt{href} and @tt{src} attribute values in
 @secref["discovery-proc" #:doc '(lib "polyglot/scribblings/polyglot.scrbl")].
 
 You can leverage this along with Racket module dependencies to generate
@@ -307,8 +307,8 @@ body {
 }
 }|
 
-The output CSS is not minified and does not
-process @litchar{@"@"import} statements.
+The output CSS is not minified. This process does not alter
+@litchar{@"@"import} at-rules.
 
 @subsection{Default File Handling}
 Any other files you reference are copied to @racket[(dist-rel)],

--- a/scribblings/workflows.scrbl
+++ b/scribblings/workflows.scrbl
@@ -271,6 +271,45 @@ HTML to disk.
 You can use this technique to take full responsibility for how
 an asset is used in a distribution within a built-in workflow.
 
+@subsection{CSS Handling (@racket[".css"])}
+In CSS, the values in @litchar{url()} expressions are evaluated just
+like @tt{href} and @tt{src} attribute values in
+@secref["discovery-proc" #:doc '(lib "polyglot/scribblings/polyglot.scrbl")].
+
+You can leverage this along with Racket module dependencies to generate
+assets for presentation.
+
+Consider this stylesheet:
+
+@verbatim|{
+@font-face {
+  font-family: 'UberFont';
+  src: url('uberfont.ttf');
+}
+
+body {
+  background-image: url(generate-background.rkt);
+  font-family: UberFont;
+}
+}|
+
+By the rules discussed, it may become:
+
+@verbatim|{
+@font-face {
+  font-family: 'UberFont';
+  src: url('82e2ab1f.ttf');
+}
+
+body {
+  background-image: url(b7ee41cd.png);
+  font-family: UberFont;
+}
+}|
+
+The output CSS is not minified and does not
+process @litchar{@"@"import} statements.
+
 @subsection{Default File Handling}
 Any other files you reference are copied to @racket[(dist-rel)],
 such that the file name is the first eight characters of the SHA1 hash of the


### PR DESCRIPTION
For #29

`polyglot` does not consider the values inside `url()` expressions during dependency discovery. 
Since Racket does not yet have a CSS parser, I settled for regular expressions for now.

@xy2iii please verify functionality locally on your site using `raco pkg install --link`.