### PR TITLE
txexpr optimization and correctness pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ upgrade until you have reason to do so, and if you are starting out
 with this project, you should use the latest version.
 
 ## Unreleased
-* Fixed broken `run-txexpr/functional!` contract
+* Fixed broken `run-txexpr/functional!` contract.
+* Fixed incorrect return value specs in `polyglot/txexpr` manual.
+* Wrote `safe` submodules to move expensive contracts aside for default use.
 
 ## [2.7] - 2019-12-28
 * Fix doc link in README

--- a/functional.rkt
+++ b/functional.rkt
@@ -1,16 +1,22 @@
 #lang racket/base
 
-(require racket/contract)
 (provide polyglot/functional%
-         (contract-out
-          [current-replace-element-predicate (parameter/c (-> txexpr? any/c))]
-          [run-txexpr/functional! (-> (or/c txexpr? (non-empty-listof txexpr?))
-                                      txexpr?)]
+         current-replace-element-predicate
+         run-txexpr/functional!
+         tx-replace-me)
 
-          [tx-replace-me (-> txexpr?
-                             (-> txexpr?
-                                 (listof txexpr-element?))
-                             txexpr?)]))
+(module+ safe
+  (require racket/contract)
+  (provide polyglot/functional%
+           (contract-out
+            [current-replace-element-predicate (parameter/c (-> txexpr? any/c))]
+            [run-txexpr/functional! (-> (or/c txexpr? (non-empty-listof txexpr?))
+                                        txexpr?)]
+            [tx-replace-me (-> txexpr?
+                               (-> txexpr?
+                                   (listof txexpr-element?))
+                               txexpr?)])))
+
 
 (require racket/class
          racket/file

--- a/functional.rkt
+++ b/functional.rkt
@@ -37,7 +37,7 @@
       (for/list ([x (in-list matches)])
         (script-info x
                      (write-script x tmpd)
-                     (λ (other) (and (txexpr? other)
+                     (λ (other) (and (txexpr-has-attrs? other)
                                      (equal? (attr-ref other 'id #f)
                                              (attr-ref x 'id))))))
       '()))
@@ -58,7 +58,7 @@
   (define all-ids
     (map (λ (with-id) (attr-ref with-id 'id))
          (or (findf*-txexpr page
-                            (λ (x) (and (txexpr? x)
+                            (λ (x) (and (txexpr-has-attrs? x)
                                         (attrs-have-key? x 'id)
                                         (attr-ref x 'id #f))))
              '())))
@@ -197,7 +197,7 @@
     (define (group! type)
       (group-scripts! tx
                       tmpd
-                      (λ (x) (and (txexpr? x)
+                      (λ (x) (and (list? x)
                                   (equal? (attr-ref x 'type #f)
                                           type)))))
 

--- a/imperative.rkt
+++ b/imperative.rkt
@@ -1,12 +1,18 @@
 #lang racket/base
 
-(require racket/contract)
 (provide polyglot/imperative%
          (rename-out [polyglot/imperative% polyglot%]
                      [run-txexpr/imperative! run-txexpr!])
-         (contract-out
-          [run-txexpr/imperative! (-> (or/c (non-empty-listof txexpr?) txexpr?)
-                                      (non-empty-listof txexpr?))]))
+         run-txexpr/imperative!)
+
+(module+ safe
+  (require racket/contract)
+  (provide polyglot/imperative%
+           (rename-out [polyglot/imperative% polyglot%]
+                       [run-txexpr/imperative! run-txexpr!])
+           (contract-out
+            [run-txexpr/imperative! (-> (or/c (non-empty-listof txexpr?) txexpr?)
+                                        (non-empty-listof txexpr?))])))
 
 (require racket/class
          racket/dict

--- a/scribblings/reference/functional.scrbl
+++ b/scribblings/reference/functional.scrbl
@@ -8,7 +8,9 @@
 
 @title{@tt{polyglot/functional}}
 
-@defmodule[polyglot/functional]
+@defmodule[#:multi (polyglot/functional (submod polyglot/functional safe))]
+
+To use module-level contracts, require the @racket[safe] submodule.
 
 @defclass[polyglot/functional% polyglot/base% ()]{
 Specializes @racket[polyglot/base%] to process Markdown files

--- a/scribblings/reference/imperative.scrbl
+++ b/scribblings/reference/imperative.scrbl
@@ -8,12 +8,14 @@
 
 @title{@tt{polyglot/imperative}}
 
-@defmodule[polyglot/imperative]
+@defmodule[#:multi (polyglot/imperative (submod polyglot/imperative safe))]
 
 The Imperative Workflow seeks application elements within Markdown
 files and runs them under the expectation that they will produce
 content as a side-effect. In that sense, app elements behave similarly
 to @litchar{<?php echo ...; ?>} in PHP.
+
+To use module-level contracts, require the @racket[safe] submodule.
 
 @defclass[polyglot/imperative% polyglot/base% ()]{
 Implements the imperative workflow.

--- a/scribblings/reference/txexpr.scrbl
+++ b/scribblings/reference/txexpr.scrbl
@@ -114,7 +114,8 @@ matching elements.
                      txexpr?]{
 Replaces each element @tt{E} matching a predicate with the list of elements
 returned from @tt{(replace E)}. Note that this can create empty parent elements.
-Acts as a shorthand for @racket[substitute-many-in-txexpr].
+Behaves like @racket[substitute-many-in-txexpr], except it only returns the
+first value.
 }
 
 @defproc[(tx-replace-tagged [tx txexpr?]
@@ -245,14 +246,16 @@ discovered build-time assets are replaced with production-ready assets.
                                 txexpr?])]{
 Aggressive variants of @racket[tx-replace] and @racket[tx-replace-tagged].
 
-Acts as a shorthand for @racket[substitute-many-in-txexpr/loop].
+Acts as a shorthand for @racket[substitute-many-in-txexpr/loop], except
+it only returns the first value.
 }
 
 @defproc[(substitute-many-in-txexpr/loop [tx txexpr?]
                                          [replace? (-> txexpr? any/c)]
                                          [replace (-> txexpr? (listof txexpr?))]
                                          [#:max-replacements max-replacements exact-integer? 1000])
-                                         txexpr?]{
+                                         (values (or/c (listof txexpr-element?) txexpr?)
+                                                 (listof txexpr?))]{
 Repeats @racket[substitute-many-in-txexpr] until no substitutions
 are possible. To illustrate, this would not terminate if it weren't for
 @tt{max-replacements}:
@@ -265,6 +268,8 @@ are possible. To illustrate, this would not terminate if it weren't for
 
 @racket[substitute-many-in-txexpr/loop] raises @racket[exn:fail] if
 it iterates once more after performing @tt{max-replacements}.
+
+The return values are like those returned from @racket[substitute-many-in-txexpr].
 }
 
 @defproc[

--- a/scribblings/reference/txexpr.scrbl
+++ b/scribblings/reference/txexpr.scrbl
@@ -8,10 +8,13 @@
          polyglot]
 
 @title{@tt{polyglot/txexpr}: Workflows from Scratch}
-@defmodule[polyglot/txexpr]
+
+@defmodule[#:multi (polyglot/txexpr (submod polyglot/txexpr safe))]
 
 This module provides all bindings from the @racketmodname[txexpr] and
 @racketmodname[xml] modules, plus the below.
+
+To use module-level contracts, require the @racket[safe] submodule.
 
 @racketmodname[polyglot/txexpr] offers workflow-independent tools to define
 where programs exist within annotated documents, and to create new documents

--- a/txexpr.rkt
+++ b/txexpr.rkt
@@ -33,9 +33,7 @@
          tx-replace-tagged/aggressive
          interlace-txexprs
          apply-manifest
-         discover-dependencies
-         get-dependency-ref
-         get-dependency-key)
+         discover-dependencies)
 
 (module+ safe
   (provide

--- a/txexpr.rkt
+++ b/txexpr.rkt
@@ -19,68 +19,88 @@
 (define replaced/c (listof txexpr?))
 
 (provide (all-from-out txexpr xml)
-         (contract-out [get-text-elements
-                        (-> txexpr? (listof string?))]
-                       [genid (-> txexpr?
-                                  string?)]
-                       [tag-equal?
-                        (-> symbol?
-                            any/c
-                            boolean?)]
-                       [make-tag-predicate
-                        (-> (non-empty-listof symbol?)
-                            (-> any/c boolean?))]
-                       [tx-search-tagged
-                        (-> txexpr?
-                            symbol?
-                            (listof txexpr-element?))]
-                       [substitute-many-in-txexpr
-                        (-> txexpr?
-                            txe-predicate/c
-                            replacer/c
-                            (values transformed/c replaced/c))]
-                       [substitute-many-in-txexpr/loop
-                        (->* (txexpr?
-                              txe-predicate/c
-                              replacer/c)
-                             (#:max-replacements exact-integer?)
-                             (values transformed/c replaced/c))]
-                       [tx-replace
-                        (-> txexpr?
-                            txe-predicate/c
-                            (-> txexpr-element? (listof txexpr?))
-                            txexpr?)]
-                       [tx-replace-tagged
-                        (-> txexpr?
-                            symbol?
-                            (-> txexpr? (listof txexpr?))
-                            txexpr?)]
-                       [tx-replace/aggressive
-                        (-> txexpr?
-                            txe-predicate/c
-                            (-> txexpr-element? (listof txexpr?))
-                            txexpr?)]
-                       [tx-replace-tagged/aggressive
-                        (-> txexpr?
-                            symbol?
-                            (-> txexpr? (listof txexpr?))
-                            txexpr?)]
-                       [interlace-txexprs
-                        (->* ((or/c txexpr?
-                                    (non-empty-listof txexpr?))
-                              (or/c txe-predicate/c
-                                    (non-empty-listof txe-predicate/c))
-                              (or/c replacer/c
-                                    (non-empty-listof replacer/c)))
-                             (#:max-replacements exact-integer?
-                              #:max-passes exact-integer?)
-                             (non-empty-listof txexpr?))]
-                       [discover-dependencies (-> txexpr?
-                                                  (listof string?))]
-                       [apply-manifest (->* (txexpr?
-                                             dict?)
-                                            ((-> path-string? string?))
-                                            txexpr?)]))
+         get-text-elements
+         genid
+         tag-equal?
+         make-tag-predicate
+         tx-search-tagged
+         txexpr-has-attrs?
+         substitute-many-in-txexpr
+         substitute-many-in-txexpr/loop
+         tx-replace
+         tx-replace-tagged
+         tx-replace/aggressive
+         tx-replace-tagged/aggressive
+         interlace-txexprs
+         apply-manifest
+         discover-dependencies
+         get-dependency-ref
+         get-dependency-key)
+
+(module+ safe
+  (provide
+   (contract-out [get-text-elements
+                  (-> txexpr? (listof string?))]
+                 [genid (-> txexpr?
+                            string?)]
+                 [tag-equal?
+                  (-> symbol?
+                      any/c
+                      boolean?)]
+                 [make-tag-predicate
+                  (-> (non-empty-listof symbol?)
+                      (-> any/c boolean?))]
+                 [tx-search-tagged
+                  (-> txexpr?
+                      symbol?
+                      (listof txexpr-element?))]
+                 [substitute-many-in-txexpr
+                  (-> txexpr?
+                      txe-predicate/c
+                      replacer/c
+                      (values transformed/c replaced/c))]
+                 [substitute-many-in-txexpr/loop
+                  (->* (txexpr?
+                        txe-predicate/c
+                        replacer/c)
+                       (#:max-replacements exact-integer?)
+                       (values transformed/c replaced/c))]
+                 [tx-replace
+                  (-> txexpr?
+                      txe-predicate/c
+                      (-> txexpr-element? (listof txexpr?))
+                      txexpr?)]
+                 [tx-replace-tagged
+                  (-> txexpr?
+                      symbol?
+                      (-> txexpr? (listof txexpr?))
+                      txexpr?)]
+                 [tx-replace/aggressive
+                  (-> txexpr?
+                      txe-predicate/c
+                      (-> txexpr-element? (listof txexpr?))
+                      txexpr?)]
+                 [tx-replace-tagged/aggressive
+                  (-> txexpr?
+                      symbol?
+                      (-> txexpr? (listof txexpr?))
+                      txexpr?)]
+                 [interlace-txexprs
+                  (->* ((or/c txexpr?
+                              (non-empty-listof txexpr?))
+                        (or/c txe-predicate/c
+                              (non-empty-listof txe-predicate/c))
+                        (or/c replacer/c
+                              (non-empty-listof replacer/c)))
+                       (#:max-replacements exact-integer?
+                        #:max-passes exact-integer?)
+                       (non-empty-listof txexpr?))]
+                 [discover-dependencies (-> txexpr?
+                                            (listof string?))]
+                 [apply-manifest (->* (txexpr?
+                                       dict?)
+                                      ((-> path-string? string?))
+                                      txexpr?)])))
 
 (define get-text-elements (curry filter string?))
 


### PR DESCRIPTION
There are two existing problems:

1. Polyglot builds are _unforgivably_ slow. I'm at 25 seconds for a small site on 3m bytecode.
2. There are some errors in `polyglot/txexpr` documentation and in one contract dealing in returned txexpr values.

The second problem was easy to fix.

I caused the first problem by using `txexpr?` in module level contracts. To keep parity with the `txexpr` module I introduced a `safe` submodule where needed to make module-level contracts optional. This alone dropped my build time to 11 seconds. Still slow, but no one can ignore a drop that huge.

This change will not break your code outright. But as of v2.8 there will be no module-level contract protections on any procedure that deals in tagged X-expressions for `polyglot/imperative`, `polyglot/functional`, or `polyglot/txexpr`. Require the `safe` submodule if you want them back.